### PR TITLE
Remove ping stderr from cron_execution

### DIFF
--- a/3rdparty/networks_ping.class.php
+++ b/3rdparty/networks_ping.class.php
@@ -54,9 +54,9 @@ class networks_Ping {
 		$ttl = escapeshellcmd($this->ttl);
 		$host = escapeshellcmd($this->host);
 		if ($_mode == 'arp') {
-			$exec_string = 'sudo arping -c 10 -C 1 -w 500000 ' . $host;
+			$exec_string = 'sudo arping -c 10 -C 1 -w 500000 ' . $host . ' 2> /dev/null';
 		} else {
-			$exec_string = 'sudo ping -n -c 1 -t ' . $ttl . ' ' . $host;
+			$exec_string = 'sudo ping -n -c 1 -t ' . $ttl . ' ' . $host . ' 2> /dev/null';
 		}
 		exec($exec_string, $output, $return);
 		$output = array_values(array_filter($output));


### PR DESCRIPTION
Bonjour,

Dans le cadre de mon ménage d'automne dans les logs, je te propose l'amélioration suivante.

Il se trouve que j'ai fréquemment des erreurs dans cron_execution lors de problèmes de résolution DNS :
```
ping: unknown host esp-bur.appart.mydomain.ext.
ping: unknown host osmc.appart.mydomain.ext.
ping: unknown host osmc.appart.mydomain.ext.
ping: unknown host tel-jean.appart.mydomain.ext.
ping: unknown host esp-ent.appart.mydomain.ext.
ping: unknown host esp-ch.appart.mydomain.ext.
ping: unknown host tel-mn.appart.mydomain.ext.
ping: unknown host esp-bur.appart.mydomain.ext.
ping: unknown host tel-mn.appart.mydomain.ext.
```

Je vous propose donc de rediriger la sortie d'erreur de ping (et arping) vers /dev/null afin d'éviter ces messages inutiles.
Qu'en pensez-vous ?

Bad Wolf