### PR TITLE
Adding support for time units other than ms

### DIFF
--- a/3rdparty/networks_ping.class.php
+++ b/3rdparty/networks_ping.class.php
@@ -62,9 +62,16 @@ class networks_Ping {
 		$output = array_values(array_filter($output));
 		if (!empty($output[1])) {
 			if (count($output) >= 5) {
-				$response = preg_match("/time(?:=|<)(?<time>[\.0-9]+)(?:|\s)[mu]?s/", $output[count($output)-4], $matches);
+				$response = preg_match("/time(?:=|<)(?<time>[\.0-9]+)(?:|\s)(?<unit>[mu]?s(ec)?)/", $output[count($output)-4], $matches);
 				if ($response > 0 && isset($matches['time'])) {
 					$latency = $matches['time'];
+					if (isset($matches['unit'])) {
+						if ($matches['unit'] == 's' || $matches['unit'] == 'sec') {
+							$latency *= 1000;
+						} elseif ($matches['unit'] == 'us' || $matches['unit'] == 'usec') {
+							$latency /= 1000;
+						}
+					}
 				}				
 			}			
 		}

--- a/3rdparty/networks_ping.class.php
+++ b/3rdparty/networks_ping.class.php
@@ -62,7 +62,7 @@ class networks_Ping {
 		$output = array_values(array_filter($output));
 		if (!empty($output[1])) {
 			if (count($output) >= 5) {
-				$response = preg_match("/time(?:=|<)(?<time>[\.0-9]+)(?:|\s)ms/", $output[count($output)-4], $matches);
+				$response = preg_match("/time(?:=|<)(?<time>[\.0-9]+)(?:|\s)[mu]?s/", $output[count($output)-4], $matches);
 				if ($response > 0 && isset($matches['time'])) {
 					$latency = $matches['time'];
 				}				


### PR DESCRIPTION
ARPING is displaying very short response times as "time=494.917 usec" instead of "time=0.495 msec"
(ARPING and other packages are up-to-date)

xxxxx@xxxxxxx-jeedom:~ $ sudo arping -c 10 -C 1 -w 500000 192.168.x.xxx
ARPING 192.168.1.22
60 bytes from 48:ba:xx:xx:xx:xx (192.168.x.xxx): index=0 time=494.917 usec

--- 192.168.x.xxx statistics ---
1 packets transmitted, 1 packets received,   0% unanswered (0 extra)
rtt min/avg/max/std-dev = 0.495/0.495/0.495/0.000 ms